### PR TITLE
Add support for placeholder attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+* [#16](https://github.com/lozjackson/ember-time-tools/pull/16) Add support for the placeholder attribute to InputDateComponent and InputTimeComponent.
+
 ### v0.3.0 2016-10-05
 
 * [#14](https://github.com/lozjackson/ember-time-tools/pull/14) Add `format` property to InputDateComponent and InputTimeComponent.

--- a/addon/components/tt-input-date.js
+++ b/addon/components/tt-input-date.js
@@ -33,6 +33,11 @@ export default Ember.Component.extend({
   */
 
   /**
+    @property placeholder
+    @type {String}
+  */
+
+  /**
     @property displayFormat
     @type {String}
     @default `ddd DD/MM/YYYY`

--- a/addon/components/tt-input-time.js
+++ b/addon/components/tt-input-time.js
@@ -32,6 +32,11 @@ export default Ember.Component.extend({
   */
 
   /**
+    @property placeholder
+    @type {String}
+  */
+
+  /**
     @property displayFormat
     @type {String}
     @default `h:mm a`

--- a/addon/templates/components/tt-input-date.hbs
+++ b/addon/templates/components/tt-input-date.hbs
@@ -4,6 +4,7 @@
   {{tt-date-field
     value=(format-date value displayFormat)
     disabled=disabled
+    placeholder=placeholder
     toggleDatePicker="toggleDatePicker"}}
   {{#if showDatePicker}}
     {{tt-date-picker

--- a/addon/templates/components/tt-input-time.hbs
+++ b/addon/templates/components/tt-input-time.hbs
@@ -4,6 +4,7 @@
   {{tt-time-field
     value=(format-date value displayFormat)
     disabled=disabled
+    placeholder=placeholder
     toggleTimePicker="toggleTimePicker"}}
   {{#if showTimePicker}}
     {{tt-time-picker

--- a/tests/dummy/app/templates/input-date.hbs
+++ b/tests/dummy/app/templates/input-date.hbs
@@ -123,6 +123,20 @@
 
 <hr>
 
+<h2>placeholder</h2>
+
+<p>
+  Set the <code>placeholder</code> attribute of the InputDateComponent.
+</p>
+
+{{code-snippet name="input-date-placeholder.hbs"}}
+
+{{! BEGIN-SNIPPET input-date-placeholder }}
+{{input-date placeholder="Placeholder text..."}}
+{{! END-SNIPPET }}
+
+<hr>
+
 <h2>disabled</h2>
 
 <p>

--- a/tests/dummy/app/templates/input-time.hbs
+++ b/tests/dummy/app/templates/input-time.hbs
@@ -153,6 +153,20 @@
 
 <hr>
 
+<h2>placeholder</h2>
+
+<p>
+  Set the <code>placeholder</code> attribute of the InputTimeComponent.
+</p>
+
+{{code-snippet name="input-time-placeholder.hbs"}}
+
+{{! BEGIN-SNIPPET input-time-placeholder }}
+{{input-time placeholder="Time..."}}
+{{! END-SNIPPET }}
+
+<hr>
+
 <h2>disabled</h2>
 
 {{code-snippet name="input-time-disabled.hbs"}}

--- a/tests/integration/components/tt-input-date-test.js
+++ b/tests/integration/components/tt-input-date-test.js
@@ -19,6 +19,15 @@ test('displayFormat', function(assert) {
   assert.equal(this.$('input').val(), 'Wed 24/08/1977');
 });
 
+test('placeholder', function(assert) {
+  this.set('placeholder', 'foo');
+  this.render(hbs`{{tt-input-date placeholder=placeholder}}`);
+  assert.equal(this.$('input').attr('placeholder'), 'foo');
+
+  this.set('placeholder', 'bar');
+  assert.equal(this.$('input').attr('placeholder'), 'bar');
+});
+
 test('change displayFormat', function(assert) {
   let date = new Date(1977,7,24);
   this.set('displayFormat', 'ddd DD/MM/YYYY');

--- a/tests/integration/components/tt-input-time-test.js
+++ b/tests/integration/components/tt-input-time-test.js
@@ -21,6 +21,15 @@ test('displayFormat', function(assert) {
   assert.equal(this.$('input').val(), '3:05 pm');
 });
 
+test('placeholder', function(assert) {
+  this.set('placeholder', 'foo');
+  this.render(hbs`{{tt-input-time placeholder=placeholder}}`);
+  assert.equal(this.$('input').attr('placeholder'), 'foo');
+
+  this.set('placeholder', 'bar');
+  assert.equal(this.$('input').attr('placeholder'), 'bar');
+});
+
 test('change displayFormat', function(assert) {
   let time = new Date(0);
   time.setHours(15);


### PR DESCRIPTION
Add support for the `placeholder` attribute to InputDate and InputTime components.

Fixes #15 