### PR TITLE
Make resetting the date optional.

### DIFF
--- a/addon/components/tt-input-time.js
+++ b/addon/components/tt-input-time.js
@@ -87,6 +87,13 @@ export default Ember.Component.extend(DestinationElementMixin, {
   scrollToSelectedTime: true,
 
   /**
+    @property resetDate
+    @type {Boolean}
+    @default `true`
+  */
+  resetDate: true,
+
+  /**
     @property showTimePicker
     @type {Boolean}
     @private

--- a/addon/components/tt-time-picker.js
+++ b/addon/components/tt-time-picker.js
@@ -85,6 +85,13 @@ export default Ember.Component.extend(ClickOutsideMixin, SetPositionMixin, {
   scrollToSelectedTime: true,
 
   /**
+    @property resetDate
+    @type {Boolean}
+    @default `true`
+  */
+  resetDate: true,
+
+  /**
     This computed property takes the `selectedTime` property, which is a javascript
     `Date` object and returns an object with `hour` and `minute` properties.
 
@@ -175,7 +182,7 @@ export default Ember.Component.extend(ClickOutsideMixin, SetPositionMixin, {
   */
   _selectTime(time) {
     let output = this.get('output');
-    let date = new Date(0);
+    let date = this.get('resetDate') ? new Date(0) : new Date();
     date.setHours(time.hour);
     date.setMinutes(time.minute);
 

--- a/addon/templates/components/tt-input-time.hbs
+++ b/addon/templates/components/tt-input-time.hbs
@@ -14,6 +14,7 @@
         selectedTime=value
         setPositionByCursor=setPositionByCursor
         scrollToSelectedTime=scrollToSelectedTime
+        resetDate=resetDate
         inputTimeElement=this.element
         select="selectTime"
         close="closeTimePicker"}}

--- a/tests/unit/components/tt-input-time-test.js
+++ b/tests/unit/components/tt-input-time-test.js
@@ -52,6 +52,13 @@ test('scrollToSelectedTime should be true', function(assert) {
   assert.equal(component.get('scrollToSelectedTime'), true);
 });
 
+test('resetDate should be true', function(assert) {
+  assert.expect(1);
+  let component = this.subject();
+  this.render();
+  assert.equal(component.get('resetDate'), true);
+});
+
 test('showTimePicker should be false', function(assert) {
   assert.expect(1);
   var component = this.subject();

--- a/tests/unit/components/tt-time-picker-test.js
+++ b/tests/unit/components/tt-time-picker-test.js
@@ -49,6 +49,13 @@ test('scrollToSelectedTime should be true', function(assert) {
   assert.equal(component.get('scrollToSelectedTime'), true);
 });
 
+test('resetDate should be true', function(assert) {
+  assert.expect(1);
+  let component = this.subject();
+  this.render();
+  assert.equal(component.get('resetDate'), true);
+});
+
 test('_selectedTime - date', function(assert) {
   assert.expect(1);
   var component = this.subject();
@@ -265,7 +272,7 @@ test('_selectTime() method - selectedTime property', function(assert) {
   assert.deepEqual(component.get('selectedTime'), date);
 });
 
-test('_selectTime() method - output = date', function(assert) {
+test('_selectTime() method - output=date resetDate=true', function(assert) {
   assert.expect(1);
   let date = new Date(0);
   date.setHours(10);
@@ -273,6 +280,26 @@ test('_selectTime() method - output = date', function(assert) {
   let component = this.subject({
     output: 'date',
     select: time => assert.deepEqual(time, date)
+  });
+  this.render();
+  component._selectTime({ hour: 10, minute: 30 });
+});
+
+test('_selectTime() method - output=date resetDate=false', function(assert) {
+  assert.expect(5);
+  let date = new Date();
+  date.setHours(10);
+  date.setMinutes(30);
+  let component = this.subject({
+    resetDate: false,
+    output: 'date',
+    select: time => {
+      assert.equal(time.getMinutes(), date.getMinutes());
+      assert.equal(time.getSeconds(), date.getSeconds());
+      assert.equal(time.getFullYear(), date.getFullYear());
+      assert.equal(time.getMonth(), date.getMonth());
+      assert.equal(time.getDate(), date.getDate());
+    }
   });
   this.render();
   component._selectTime({ hour: 10, minute: 30 });


### PR DESCRIPTION
This PR adds an option for resetting the date when selecting a time using the `TimePickerComponent`.

The default value will be `true` for now.. I might consider changing the default value to `false` if it makes sense for most users but I will not do that probably until v1.0.0 to keep backwards compatibility with the current implementation.

```
{{input-time resetDate=false}}
```

Setting `resetDate` to `false` will only set the hours/minutes portion of the date object.  It will keep todays date.

If you set `resetDate` to true, then the date will be reset to 1/1/1970, before then setting the hours and minutes - This is the current default behaviour.

The `resetDate` property can be used with the `InputTimeComponent` and the `TimePickerComponent`

Closes #32 