### PR TITLE
DatePicker and TimePicker should re-use selected value

### DIFF
--- a/addon/components/tt-date-picker.js
+++ b/addon/components/tt-date-picker.js
@@ -7,7 +7,7 @@ import DateObject from 'ember-time-tools/utils/date';
 import ClickOutsideMixin from 'ember-ui-components/mixins/click-outside';
 import SetPositionMixin from 'ember-time-tools/mixins/set-position';
 
-const { computed } = Ember;
+const { computed, get } = Ember;
 const { readOnly } = computed;
 
 /*
@@ -327,8 +327,8 @@ export default Ember.Component.extend(ClickOutsideMixin, SetPositionMixin, {
   */
   _selectDate(day) {
     let output = this.get('output');
-    let date = new Date(day.year, day.month, day.date);
-
+    let date = new Date(get(this, 'selectedDate') || 0);
+    date.setFullYear(day.year, day.month, day.date);
     if (output) {
       switch(output) {
         case 'date':

--- a/addon/components/tt-time-picker.js
+++ b/addon/components/tt-time-picker.js
@@ -176,8 +176,7 @@ export default Ember.Component.extend(ClickOutsideMixin, SetPositionMixin, {
   _selectTime(time) {
     let output = this.get('output');
     let date = new Date(get(this, 'selectedTime') || 0);
-    date.setHours(time.hour);
-    date.setMinutes(time.minute);
+    date.setHours(time.hour, time.minute);
 
     if (output) {
       switch(output) {

--- a/addon/components/tt-time-picker.js
+++ b/addon/components/tt-time-picker.js
@@ -6,7 +6,7 @@ import layout from '../templates/components/tt-time-picker';
 import ClickOutsideMixin from 'ember-ui-components/mixins/click-outside';
 import SetPositionMixin from 'ember-time-tools/mixins/set-position';
 
-const { computed, run } = Ember;
+const { computed, get, run } = Ember;
 
 /**
   @class TimePickerComponent
@@ -175,7 +175,7 @@ export default Ember.Component.extend(ClickOutsideMixin, SetPositionMixin, {
   */
   _selectTime(time) {
     let output = this.get('output');
-    let date = new Date(0);
+    let date = new Date(get(this, 'selectedTime') || 0);
     date.setHours(time.hour);
     date.setMinutes(time.minute);
 

--- a/tests/unit/components/tt-date-picker-test.js
+++ b/tests/unit/components/tt-date-picker-test.js
@@ -251,6 +251,18 @@ test('_selectDate() method - selectedDate property', function(assert) {
   assert.deepEqual(component.get('selectedDate'), date);
 });
 
+test('_selectDate() method should not alter the time part of the selectedDate property', function(assert) {
+  assert.expect(1);
+  let date = new Date(1977,7,24,10);
+
+  let component = this.subject({
+    selectedDate: new Date(2017,3,1,10)
+  });
+  this.render();
+  run(() => component._selectDate({year: 1977, month: 7, date: 24}));
+  assert.deepEqual(component.get('selectedDate'), date);
+});
+
 test('_selectDate() method - output = date', function(assert) {
   assert.expect(1);
   let date = new Date(1977,7,24);

--- a/tests/unit/components/tt-time-picker-test.js
+++ b/tests/unit/components/tt-time-picker-test.js
@@ -265,6 +265,18 @@ test('_selectTime() method - selectedTime property', function(assert) {
   assert.deepEqual(component.get('selectedTime'), date);
 });
 
+test('_selectTime() method - should not alter the date part of selectedTime property', function(assert) {
+  assert.expect(1);
+  let date = new Date();
+  date.setHours(10, 30);
+  let component = this.subject({
+    selectedTime: new Date()
+  });
+  this.render();
+  run(() => component._selectTime({ hour: 10, minute: 30 }));
+  assert.deepEqual(component.get('selectedTime'), date);
+});
+
 test('_selectTime() method - output = date', function(assert) {
   assert.expect(1);
   let date = new Date(0);


### PR DESCRIPTION
This PR changes the behaviour of the `TimePickerComponent` and `DatePickerComponent`.  The selected value is re-used and the date or time part modified.

If you start with a date of `2017-03-01 22:00`.. and then use the time picker to change the time to `9:00`, the resulting value would be `2017-03-01 9:00`.

Similarly, the date picker allows you to change the date part without changing the time.

This allows you to pass the same value to both date and time picker and adjust each part independently.

```js
{{input-date value=eventDate}}
{{input-time value=eventDate}}
```

closes #32 